### PR TITLE
Update development deployment to be inline with prod deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,16 @@
+FROM 389ds/389ds-website-ruby-27
+MAINTAINER awood@redhat.com
 
-FROM opensuse/tumbleweed:latest
-MAINTAINER william@blackhats.net.au
+USER root
+RUN mkdir -p /site && chmod 777 /site
+WORKDIR /site
 
-EXPOSE 4000
-
-RUN zypper in -y python2-Pygments gcc gcc-c++ libxml2-devel libxslt-devel \
-    ruby2.6-rubygem-bundler git make tar gzip ruby-devel && \
-    zypper clean
-
-RUN mkdir -p /root/389wiki
-WORKDIR /root/389wiki
-
-ADD ./ /root/389wiki
-
+# The gems are installed globally and the copied Gemfiles will be
+# hidden when the site source is mounted into /site
+COPY ./Gemfile* .
 RUN bundle install
 
-CMD ["jekyll", "serve", "-H", "0.0.0.0"]
-
-
+USER 1001
+# Turn off disk caching; jekyll tries to create a .jekyll-cache directory in the volume
+# mount which is doesn't have permission to do
+CMD bundle exec jekyll serve -d /tmp --disable-disk-cache --livereload -H 0.0.0.0

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -9,7 +9,7 @@ RUN yum install -y --setopt=tsflags=nodocs python3 && \
     yum clean all -y
 
 # Keep this value up to date with the BUNDLED WITH version in Gemfile.lock
-RUN gem install bundler:2.2.15
+RUN gem install bundler:2.3.10
 
 COPY ./.s2i/bin/ $STI_SCRIPTS_PATH
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,22 @@
 # 389 Directory Server Wiki
 
 ## Getting Started
+### Container Development (Easy Mode)
+1. Build the `Dockerfile.openshift` and `Dockerfile` images in that order.  You
+   can also pull the `389ds/389ds-website-ruby-27` from Quay.io.
+   ```
+   $ podman build -t 389ds/389ds-website-ruby-27 -f Dockerfile.openshift
+   $ podman build -t site-test -f Dockerfile
+   ```
+1. Run the `site-test` image with the site source mounted into it.  The `:z`
+   tells Podman to set the SELinux context on the volume.
+   ```
+   $ podman run -v .:/site:z -p 4000:4000 --rm site-test
+   ```
+1. You should only need to rebuild the underlying images if something in the
+   site software stack changes: e.g. new dependencies, library updates, etc.
 
+### Local Development (Hard Mode)
 You can test our your changes locally with:
 
 `docker build -t 389wiki:latest .`


### PR DESCRIPTION
Rather than use an entirely different Linux distribution and deployment
strategy, this commit makes the development Dockerfile derive from the
production container image. It then installs the gems and defines an
command to render the site.  Instructions in the README then outline how
to run the container such that a user can work on site documents locally
while having the site continuously render in the container.